### PR TITLE
Use a custom dart@2 formula

### DIFF
--- a/dart@2.rb
+++ b/dart@2.rb
@@ -1,0 +1,46 @@
+class DartAT2 < Formula
+  desc "The Dart SDK, version 2.x"
+  homepage "https://www.dartlang.org/"
+  version "2.0.0-dev.59.0"
+
+  keg_only :versioned_formula
+
+  if MacOS.prefer_64_bit?
+    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.59.0/sdk/dartsdk-macos-x64-release.zip"
+    sha256 "dfd929ed8b07278247b041d7573d5bb966033030c9c0122dee6b0eb0b6515850"
+  else
+    url "https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.59.0/sdk/dartsdk-macos-ia32-release.zip"
+    sha256 "3fc86c5f5e88b9f652364b33de547abf6e59033a35931eb63e0c89349f64c466"
+  end
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/dart"
+    bin.write_exec_script Dir["#{libexec}/bin/{pub,dart?*}"]
+  end
+
+  def shim_script(target)
+    <<~EOS
+      #!/usr/bin/env bash
+      exec "#{prefix}/#{target}" "$@"
+    EOS
+  end
+
+  def caveats; <<~EOS
+    Note that this is a development version of Dart.
+
+    Please note the path to the Dart SDK:
+      #{opt_libexec}
+    EOS
+  end
+
+  test do
+    (testpath/"sample.dart").write <<~EOS
+      void main() {
+        print(r"test message");
+      }
+    EOS
+
+    assert_equal "test message\n", shell_output("#{bin}/dart sample.dart")
+  end
+end

--- a/sass.rb
+++ b/sass.rb
@@ -7,13 +7,13 @@ class Sass < Formula
   url "https://github.com/sass/dart-sass/archive/1.5.0.tar.gz"
   sha256 "2239539edeaa0e46221e2962fd8f8b35121af58ed1a1a9d93c639428abb94bcf"
 
-  depends_on "dart-lang/dart/dart" => [:build, "devel"]
+  depends_on "dart@2" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart_bin = Formula["dart@2"].opt_bin
 
-    system dart/"pub", "get"
-    system dart/"dart",
+    system dart_bin/"pub", "get"
+    system dart_bin/"dart",
            "--snapshot=sass.dart.app.snapshot",
            "--snapshot-kind=app-jit",
            "bin/sass.dart", "tool/app-snapshot-input.scss"
@@ -22,16 +22,17 @@ class Sass < Formula
     # Copy the version of the Dart VM we used into our lib directory so that if
     # the user upgrades their Dart VM version it doesn't break Sass's snapshot,
     # which was compiled with an older version.
-    cp dart/"dart", lib
+    cp dart_bin/"dart", lib
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]
 
-    (bin/"sass").write <<SH
+    (buildpath/"sass").write <<EOS
 #!/bin/sh
 exec "#{lib}/dart" "-Dversion=#{version}" "#{lib}/sass.dart.app.snapshot" "$@"
-SH
-    chmod 0555, "#{bin}/sass"
+EOS
+    chmod 0555, "sass"
+    bin.install("sass")
   end
 
   test do


### PR DESCRIPTION
The current sass version requires what is currently the development
version of Dart. Homebrew does not support defining dependencies
on development versions. Instead, define a new version-specific
dart@2 formula for our own use.

Also changes the multi-line string to use Homebrew's conventional `EOS` terminator.