### PR TITLE
Set a PUB_ENVIRONMENT environment variable

### DIFF
--- a/sass.rb
+++ b/sass.rb
@@ -12,6 +12,8 @@ class Sass < Formula
   def install
     dart = Formula["dart-lang/dart/dart@2"].opt_bin
 
+    # Tell the pub server where these installations are coming from.
+    ENV["PUB_ENVIRONMENT"] = "Homebrew: Sass"
     system dart/"pub", "get"
     system dart/"dart",
            "--snapshot=sass.dart.app.snapshot",


### PR DESCRIPTION
This tells the pub.dartlang.org server where these downloads are coming from.

Requested by @kevmoo to make it easier to separate out Sass users.