### PR TITLE
sass: work around Homebrew bug

### DIFF
--- a/migrator.rb
+++ b/migrator.rb
@@ -10,7 +10,7 @@ class Migrator < Formula
   depends_on "dart-lang/dart/dart" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart = Formula["dart-lang/dart/dart"].libexec/"bin"
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]

--- a/migrator@1.2.3-test.2.rb
+++ b/migrator@1.2.3-test.2.rb
@@ -10,7 +10,7 @@ class MigratorAT123Test2 < Formula
   depends_on "dart-lang/dart/dart" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart = Formula["dart-lang/dart/dart"].libexec/"bin"
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]

--- a/sass.rb
+++ b/sass.rb
@@ -10,7 +10,7 @@ class Sass < Formula
   depends_on "dart-lang/dart/dart" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart = Formula["dart-lang/dart/dart"].libexec/"bin"
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]

--- a/sass@1.26.0-test.1.rb
+++ b/sass@1.26.0-test.1.rb
@@ -10,7 +10,7 @@ class SassAT1260Test1 < Formula
   depends_on "dart-lang/dart/dart" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart = Formula["dart-lang/dart/dart"].libexec/"bin"
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]

--- a/sass@1.26.0-test.2.rb
+++ b/sass@1.26.0-test.2.rb
@@ -10,7 +10,7 @@ class SassAT1260Test2 < Formula
   depends_on "dart-lang/dart/dart" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart = Formula["dart-lang/dart/dart"].libexec/"bin"
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]

--- a/sass@1.26.0-test.3.rb
+++ b/sass@1.26.0-test.3.rb
@@ -10,7 +10,7 @@ class SassAT1260Test3 < Formula
   depends_on "dart-lang/dart/dart" => :build
 
   def install
-    dart = Formula["dart-lang/dart/dart"].opt_bin
+    dart = Formula["dart-lang/dart/dart"].libexec/"bin"
 
     pubspec = YAML.safe_load(File.read("pubspec.yaml"))
     version = pubspec["version"]


### PR DESCRIPTION
A recent Homebrew bug has broken the ability to run packages' Homebrew-generated binstub scripts inside another package's `install` method. This will get fixed upstream, but in the meantime this fix unblocks Sass by fixing the build. The fix works by running the real underlying `dart` executable instead of the broken binstub.

Fixes #34.