### PR TITLE
Fix JIT snapshot installation

### DIFF
--- a/sass.rb
+++ b/sass.rb
@@ -53,7 +53,7 @@ class Sass < Formula
     system _dart/"dart", "compile", "jit-snapshot",
            "-Dversion=#{_version}",
            "-o", "sass.dart.app.snapshot",
-           "bin/sass.dart", "tool/app-snapshot-input.scss"
+           "bin/sass.dart", "--version"
     lib.install "sass.dart.app.snapshot"
 
     # Copy the version of the Dart VM we used into our lib directory so that if


### PR DESCRIPTION
The jit snapshot installation is almost never used, that it only happens on extremely rare 32-bit linuxbrew, so that no one noticed that it was actually broken due to the training input got removed from dart-sass. This PR fixes the installation on 32-bit linuxbrew.