### PR TITLE
Use the actual version than inferred version for dart-sass-embedded

### DIFF
--- a/dart-sass-embedded.rb
+++ b/dart-sass-embedded.rb
@@ -41,9 +41,7 @@ class DartSassEmbedded < Formula
   end
 
   def _version
-    # The next line is current broken: https://github.com/sass/dart-sass-embedded/pull/121
-    # @_version ||= YAML.safe_load(File.read("pubspec.yaml"))["version"]
-    @_version ||= version
+    @_version ||= YAML.safe_load(File.read("pubspec.yaml"))["version"]
   end
 
   def _protocol_version


### PR DESCRIPTION
The lines were commented out due to syntax in  yaml was not parsable by ruby, now with 1.56.2, the syntax issue is fixed.